### PR TITLE
log dropped connections

### DIFF
--- a/client.sh
+++ b/client.sh
@@ -120,6 +120,13 @@ else
 	labelok; echo -en " Configured TimeZone: "; clr_blueb clr_white " ${TIMEZONE} ";
 fi
 
+CHECKSECTHEMALLCHAINLOGDROP=$(iptables -L -n | grep -i 'Chain' | grep 'secthemall-logdrop' | wc -l)
+if [[ "${CHECKSECTHEMALLCHAINLOGDROP}" == "0" ]]; then
+	labelwa; echo " secthemall iptables logdrop does not exists, creating it..."
+	iptables -N secthemall-logdrop
+	iptables -A secthemall-logdrop -j LOG --log-level info --log-prefix "SECTHEMALL logdrop: "
+	iptables -A secthemall-logdrop -j DROP
+fi
 
 CHECKSECTHEMALLCHAINBL=$(iptables -L -n | grep -i 'Chain' | grep 'secthemall-blacklist' | wc -l)
 if [[ "${CHECKSECTHEMALLCHAINBL}" == "0" ]]; then
@@ -170,6 +177,14 @@ else
 fi
 
 if type "ip6tables" > /dev/null; then
+	CHECKSECTHEMALLCHAINLOGDROP6=$(ip6tables -L -n | grep -i 'Chain' | grep 'secthemall-logdrop' | wc -l)
+	if [[ "${CHECKSECTHEMALLCHAINLOGDROP6}" == "0" ]]; then
+		labelwa; echo " secthemall ip6tables logdrop does not exists, creating it..."
+		ip6tables -N secthemall-logdrop
+		ip6tables -A secthemall-logdrop -j LOG --log-level info --log-prefix "SECTHEMALL logdrop: "
+		ip6tables -A secthemall-logdrop -j DROP
+	fi
+
 	CHECKSECTHEMALLCHAINBL6=$(ip6tables -L -n | grep -i 'Chain' | grep 'secthemall-blacklist' | wc -l)
 	if [[ "${CHECKSECTHEMALLCHAINBL6}" == "0" ]]; then
 		labelwa; echo " secthemall ip6tables blacklist does not exists, creating it..."

--- a/inc/autoconf.sh
+++ b/inc/autoconf.sh
@@ -98,6 +98,16 @@ if [ $FAIL2BANLOGS -ge 1 ]; then
 	done
 fi
 
+echo -e "\n+ SECTHEMALL can logs dropped connections from blacklisted IPs"
+echo -e "+ by reading iptables logs stored in /var/log/"
+echo -n "+ Do you want to add it on secthemall.conf? [Y/n] "
+read LOGRES
+LOGRESOUT=$(echo "${LOGRES}" | egrep -i "^(y|yes|)$" | wc -l);
+if [ $LOGRESOUT -ge 1 ]; then
+	CONFOUT[8]=$(echo cmd '"logdrop"' '"secthemall_logdrop"' '"egrep -s SECTHEMALL.logdrop /var/log/*"')
+fi
+
+
 
 if [ ${#CONFOUT[*]} -ge 1 ]; then
 	echo -en "\n+ I'm going to write ${#CONFOUT[*]} line(s) on secthemall.conf file. Do you want to continue? [Y/n] "

--- a/inc/functions.sh
+++ b/inc/functions.sh
@@ -117,7 +117,7 @@ function parsecmd {
 		exit 0
 	fi
 
-	curl -d "a=writelogs&tz=${TIMEZONE}&username=${USERNAME}&apikey=${APIKEY}&type=${logptye}&alias=${SALIAS}&hostname=${MYHOSTNAME}&ipaddr=${MYIPADDR}" -d @${CDIR}/../tmp/e${logfile//\//_} "https://wl.secthemall.com/api/v1/"
+	curl -s -d "a=writelogs&tz=${TIMEZONE}&username=${USERNAME}&apikey=${APIKEY}&type=${logptye}&alias=${SALIAS}&hostname=${MYHOSTNAME}&ipaddr=${MYIPADDR}" -d @${CDIR}/../tmp/e${logfile//\//_} "https://wl.secthemall.com/api/v1/"
 	labelok; echo -n " Logs sent for file "; clr_blue "${logfile}"
 	rm -rf ${CDIR}/../tmp/t${logfile//\//_}
 	rm -rf ${CDIR}/../tmp/e${logfile//\//_}
@@ -131,7 +131,7 @@ function getblacklist {
 	iptables -F secthemall-blacklist
 	GETBLACKLIST4=$(curl -s -d "a=getmyblacklist&ipversion=ipv4&tz=${TIMEZONE}&username=${USERNAME}&apikey=${APIKEY}&alias=${SALIAS}&hostname=${MYHOSTNAME}&ipaddr=${MYIPADDR}" "https://secthemall.com/api/v1/")
 	for ip in $GETBLACKLIST4; do
-		iptables -I secthemall-blacklist -s ${ip} -j DROP
+		iptables -I secthemall-blacklist -s ${ip} -j secthemall-logdrop
 	done;
 	labelok; echo " Blacklist v4 synced."
 
@@ -139,7 +139,7 @@ function getblacklist {
 		ip6tables -F secthemall-blacklist > /dev/null 2>&1
 		GETBLACKLIST6=$(curl -s -d "a=getmyblacklist&ipversion=ipv6&tz=${TIMEZONE}&username=${USERNAME}&apikey=${APIKEY}&alias=${SALIAS}&hostname=${MYHOSTNAME}&ipaddr=${MYIPADDR}" "https://secthemall.com/api/v1/")
 		for ip in $GETBLACKLIST6; do
-			ip6tables -I secthemall-blacklist -s ${ip} -j DROP > /dev/null 2>&1
+			ip6tables -I secthemall-blacklist -s ${ip} -j secthemall-logdrop > /dev/null 2>&1
 		done;
 		labelok; echo " Blacklist v6 synced."
 	fi
@@ -153,7 +153,7 @@ function gettorexitnodes {
 	iptables -F secthemall-tor
 	GETBLACKLIST4=$(curl -s -u ${USERNAME}:${APIKEY} "https://secthemall.com/public-list/tor-exit-nodes/iplist?size=3000")
 	for ip in $GETBLACKLIST4; do
-		iptables -I secthemall-tor -s ${ip} -j DROP
+		iptables -I secthemall-tor -s ${ip} -j secthemall-logdrop
 	done;
 	labelok; echo " Tor Blacklist synced."
 }

--- a/inc/getcountries.sh
+++ b/inc/getcountries.sh
@@ -22,7 +22,7 @@ function get_countries_blocks {
 	iptables -F secthemall-countries
 	UPDATESOUT=$(curl -s -A "${STAVERSION}" -d "a=getcountries&tz=${TIMEZONE}&username=${USERNAME}&apikey=${APIKEY}&alias=${SALIAS}" 'https://secthemall.com/api/v1/')
 	for ip in $UPDATESOUT; do
-		iptables -I secthemall-countries -s ${ip} -j DROP
+		iptables -I secthemall-countries -s ${ip} -j secthemall-logdrop
 	done;
 	labelok; echo " Countries Blacklist v4 synced."
 }

--- a/inc/getupdates.sh
+++ b/inc/getupdates.sh
@@ -45,7 +45,7 @@ for uout in $UPDATESOUT; do
 			if [ $ISIPV4 -ge 1 ]; then
 				CHECKIFIPEXISTS=$(iptables -L secthemall-blacklist -n | grep -w "${ip}" | wc -l)
 				if [ $CHECKIFIPEXISTS -eq 0 ]; then
-					iptables -I secthemall-blacklist -s ${ip} -j DROP
+					iptables -I secthemall-blacklist -s ${ip} -j secthemall-logdrop
 				else
 					labelwa; echo " IPv4 ${ip} already in blacklist."
 				fi
@@ -83,10 +83,10 @@ for uout in $UPDATESOUT; do
 			if [ $ISIPV4 -ge 1 ]; then
 				CHECKIFIPEXISTS=$(iptables -L secthemall-blacklist -n | grep -w "${ip}" | wc -l)
 				if [ $CHECKIFIPEXISTS -ge 1 ]; then
-					iptables -D secthemall-blacklist -s ${ip} -j DROP > /dev/null 2>&1
+					iptables -D secthemall-blacklist -s ${ip} -j secthemall-logdrop > /dev/null 2>&1
 				else
 					labelwa; echo " IPv4 ${ip} does not seem to be blacklisted, trying to remove it anyway."
-					iptables -D secthemall-blacklist -s ${ip} -j DROP > /dev/null 2>&1
+					iptables -D secthemall-blacklist -s ${ip} -j secthemall-logdrop > /dev/null 2>&1
 				fi
 			fi
 		done
@@ -131,7 +131,7 @@ for uout in $UPDATESOUT; do
 			if [ $ISIPV6 -ge 1 ]; then
 				CHECKIFIPEXISTS=$(ip6tables -L secthemall-blacklist -n | grep -w "${ip}" | wc -l)
 				if [ $CHECKIFIPEXISTS -eq 0 ]; then
-					ip6tables -I secthemall-blacklist -s ${ip} -j DROP
+					ip6tables -I secthemall-blacklist -s ${ip} -j secthemall-logdrop
 				else
 					labelwa; echo " IPv6 ${ip} already in blacklist."
 				fi
@@ -169,10 +169,10 @@ for uout in $UPDATESOUT; do
 			if [ $ISIPV6 -ge 1 ]; then
 				CHECKIFIPEXISTS=$(ip6tables -L secthemall-blacklist -n | grep -w "${ip}" | wc -l)
 				if [ $CHECKIFIPEXISTS -ge 1 ]; then
-					ip6tables -D secthemall-blacklist -s ${ip} -j DROP > /dev/null 2>&1
+					ip6tables -D secthemall-blacklist -s ${ip} -j secthemall-logdrop > /dev/null 2>&1
 				else
 					labelwa; echo " IPv6 ${ip} does not seem to be blacklisted, trying to remove it anyway."
-					ip6tables -D secthemall-blacklist -s ${ip} -j DROP > /dev/null 2>&1
+					ip6tables -D secthemall-blacklist -s ${ip} -j secthemall-logdrop > /dev/null 2>&1
 				fi
 			fi
 		done


### PR DESCRIPTION
This PR makes able the bash client to log dropped connections from blacklisted IPs to the SECTHEMALL dashboard. 

The default iptables action is no more `DROP` but a chain named `iptables-logdrop` that logs with prefix `SECTHEMALL logdrop` and then drop the pkt. 

The bash client will look for `SECTHEMALL logdrop` in `/var/log/` and send all diffs to wl.

<img width="1440" alt="Schermata 2019-03-14 alle 16 07 02" src="https://user-images.githubusercontent.com/4454961/54368009-a67e7700-4673-11e9-8641-4a2a107ec780.png">
